### PR TITLE
Fixed typo in write_quantification_commands for Salmon

### DIFF
--- a/piquant/quantifiers.py
+++ b/piquant/quantifiers.py
@@ -433,7 +433,7 @@ class _Salmon(_TranscriptomeBasedQuantifierBase):
             index_dir=index_dir,
             library_spec=library_spec,
             reads_spec=reads_spec))
-        writer.add_pipe(cls.FILTER_COMMENT_LINES)
+        writer.add_pipe(*cls.FILTER_COMMENT_LINES)
 
     @classmethod
     def write_post_quantification_cleanup(cls, writer):


### PR DESCRIPTION
cls.FILTER_COMMENT_LINES needs to be splatted (is this what they call it in Python?) before being passed into write.add_pipe.
